### PR TITLE
Custom Exception instead of Validation Exception

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4851,16 +4851,16 @@
         },
         {
             "name": "composer/composer",
-            "version": "2.1.5",
+            "version": "2.1.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/composer.git",
-                "reference": "ac679902e9f66b85a8f9d8c1c88180f609a8745d"
+                "reference": "24d38e9686092de05214cafa187dc282a5d89497"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/composer/zipball/ac679902e9f66b85a8f9d8c1c88180f609a8745d",
-                "reference": "ac679902e9f66b85a8f9d8c1c88180f609a8745d",
+                "url": "https://api.github.com/repos/composer/composer/zipball/24d38e9686092de05214cafa187dc282a5d89497",
+                "reference": "24d38e9686092de05214cafa187dc282a5d89497",
                 "shasum": ""
             },
             "require": {
@@ -4927,9 +4927,9 @@
                 "package"
             ],
             "support": {
-                "irc": "irc://irc.freenode.org/composer",
+                "irc": "ircs://irc.libera.chat:6697/composer",
                 "issues": "https://github.com/composer/composer/issues",
-                "source": "https://github.com/composer/composer/tree/2.1.5"
+                "source": "https://github.com/composer/composer/tree/2.1.8"
             },
             "funding": [
                 {
@@ -4945,7 +4945,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-07-23T08:35:47+00:00"
+            "time": "2021-09-15T11:55:15+00:00"
         },
         {
             "name": "composer/metadata-minifier",
@@ -5523,16 +5523,16 @@
         },
         {
             "name": "doctrine/dbal",
-            "version": "3.1.1",
+            "version": "3.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/dbal.git",
-                "reference": "8e0fde2b90e3f61361013d1e928621beeea07bc0"
+                "reference": "3ee2622b57370c786f531678f6641208747f7bfc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/dbal/zipball/8e0fde2b90e3f61361013d1e928621beeea07bc0",
-                "reference": "8e0fde2b90e3f61361013d1e928621beeea07bc0",
+                "url": "https://api.github.com/repos/doctrine/dbal/zipball/3ee2622b57370c786f531678f6641208747f7bfc",
+                "reference": "3ee2622b57370c786f531678f6641208747f7bfc",
                 "shasum": ""
             },
             "require": {
@@ -5544,15 +5544,15 @@
             },
             "require-dev": {
                 "doctrine/coding-standard": "9.0.0",
-                "jetbrains/phpstorm-stubs": "2020.2",
-                "phpstan/phpstan": "0.12.81",
-                "phpstan/phpstan-strict-rules": "^0.12.2",
+                "jetbrains/phpstorm-stubs": "2021.1",
+                "phpstan/phpstan": "0.12.96",
+                "phpstan/phpstan-strict-rules": "^0.12.11",
                 "phpunit/phpunit": "9.5.5",
-                "psalm/plugin-phpunit": "0.13.0",
+                "psalm/plugin-phpunit": "0.16.1",
                 "squizlabs/php_codesniffer": "3.6.0",
                 "symfony/cache": "^5.2|^6.0",
                 "symfony/console": "^2.0.5|^3.0|^4.0|^5.0|^6.0",
-                "vimeo/psalm": "4.6.4"
+                "vimeo/psalm": "4.10.0"
             },
             "suggest": {
                 "symfony/console": "For helpful console commands such as SQL execution and import of files."
@@ -5612,7 +5612,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/dbal/issues",
-                "source": "https://github.com/doctrine/dbal/tree/3.1.1"
+                "source": "https://github.com/doctrine/dbal/tree/3.1.2"
             },
             "funding": [
                 {
@@ -5628,7 +5628,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-06-19T17:59:55+00:00"
+            "time": "2021-09-12T20:56:32+00:00"
         },
         {
             "name": "doctrine/deprecations",
@@ -9215,16 +9215,16 @@
         },
         {
             "name": "seld/phar-utils",
-            "version": "1.1.1",
+            "version": "1.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Seldaek/phar-utils.git",
-                "reference": "8674b1d84ffb47cc59a101f5d5a3b61e87d23796"
+                "reference": "749042a2315705d2dfbbc59234dd9ceb22bf3ff0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/phar-utils/zipball/8674b1d84ffb47cc59a101f5d5a3b61e87d23796",
-                "reference": "8674b1d84ffb47cc59a101f5d5a3b61e87d23796",
+                "url": "https://api.github.com/repos/Seldaek/phar-utils/zipball/749042a2315705d2dfbbc59234dd9ceb22bf3ff0",
+                "reference": "749042a2315705d2dfbbc59234dd9ceb22bf3ff0",
                 "shasum": ""
             },
             "require": {
@@ -9257,9 +9257,9 @@
             ],
             "support": {
                 "issues": "https://github.com/Seldaek/phar-utils/issues",
-                "source": "https://github.com/Seldaek/phar-utils/tree/master"
+                "source": "https://github.com/Seldaek/phar-utils/tree/1.1.2"
             },
-            "time": "2020-07-07T18:42:57+00:00"
+            "time": "2021-08-19T21:01:38+00:00"
         },
         {
             "name": "spatie/backtrace",
@@ -9727,85 +9727,6 @@
                 }
             ],
             "time": "2021-08-04T21:20:46+00:00"
-        },
-        {
-            "name": "symfony/polyfill-php81",
-            "version": "v1.23.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-php81.git",
-                "reference": "e66119f3de95efc359483f810c4c3e6436279436"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php81/zipball/e66119f3de95efc359483f810c4c3e6436279436",
-                "reference": "e66119f3de95efc359483f810c4c3e6436279436",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "1.23-dev"
-                },
-                "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php81\\": ""
-                },
-                "files": [
-                    "bootstrap.php"
-                ],
-                "classmap": [
-                    "Resources/stubs"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill backporting some PHP 8.1+ features to lower PHP versions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-php81/tree/v1.23.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2021-05-21T13:25:03+00:00"
         },
         {
             "name": "symfony/property-access",
@@ -10633,5 +10554,5 @@
         "php": "^7.4|^8.0"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.0.0"
 }

--- a/src/Actions/VerifyPayuBiz.php
+++ b/src/Actions/VerifyPayuBiz.php
@@ -43,7 +43,7 @@ class VerifyPayuBiz implements Actionable
     protected function url(): string
     {
         $subdomain = data_get($this->domainMap, $this->gateway->mode);
-        throw_unless($subdomain, new InvalidValueException(__('Invalid mode supplied for PayuBiz')));
+        throw_unless($subdomain, InvalidValueException::fromMessage(__('Invalid mode supplied for PayuBiz'), 'mode'));
 
         return sprintf('https://%s.payu.in/merchant/postservice?form=2', $subdomain);
     }

--- a/src/Actions/VerifyPayuBiz.php
+++ b/src/Actions/VerifyPayuBiz.php
@@ -3,7 +3,7 @@
 namespace Tzsk\Payu\Actions;
 
 use Illuminate\Support\Facades\Http;
-use Illuminate\Validation\ValidationException;
+use Tzsk\Payu\Exceptions\InvalidValueException;
 use Tzsk\Payu\Gateway\Gateway;
 use Tzsk\Payu\Gateway\PayuBiz;
 use Tzsk\Payu\Models\PayuTransaction;
@@ -43,9 +43,7 @@ class VerifyPayuBiz implements Actionable
     protected function url(): string
     {
         $subdomain = data_get($this->domainMap, $this->gateway->mode);
-        throw_unless($subdomain, ValidationException::withMessages([
-            'mode' => __('Invalid mode supplied for PayuBiz'),
-        ]));
+        throw_unless($subdomain, new InvalidValueException(__('Invalid mode supplied for PayuBiz')));
 
         return sprintf('https://%s.payu.in/merchant/postservice?form=2', $subdomain);
     }

--- a/src/Actions/VerifyPayuMoney.php
+++ b/src/Actions/VerifyPayuMoney.php
@@ -3,7 +3,7 @@
 namespace Tzsk\Payu\Actions;
 
 use Illuminate\Support\Facades\Http;
-use Illuminate\Validation\ValidationException;
+use Tzsk\Payu\Exceptions\InvalidValueException;
 use Tzsk\Payu\Gateway\Gateway;
 use Tzsk\Payu\Gateway\PayuMoney;
 use Tzsk\Payu\Models\PayuTransaction;
@@ -44,9 +44,7 @@ class VerifyPayuMoney implements Actionable
     protected function url(): string
     {
         $part = data_get($this->partMap, $this->gateway->mode);
-        throw_unless($part, ValidationException::withMessages([
-            'mode' => __('Invalid mode supplied for PayuBiz'),
-        ]));
+        throw_unless($part, new InvalidValueException(__('Invalid mode supplied for PayuBiz')));
 
         return sprintf('https://www.payumoney.com/%spayment/op/getPaymentResponse?%s', $part, $this->getQuery());
     }

--- a/src/Actions/VerifyPayuMoney.php
+++ b/src/Actions/VerifyPayuMoney.php
@@ -44,7 +44,7 @@ class VerifyPayuMoney implements Actionable
     protected function url(): string
     {
         $part = data_get($this->partMap, $this->gateway->mode);
-        throw_unless($part, new InvalidValueException(__('Invalid mode supplied for PayuBiz')));
+        throw_unless($part, InvalidValueException::fromMessage(__('Invalid mode supplied for PayuBiz'), 'mode'));
 
         return sprintf('https://www.payumoney.com/%spayment/op/getPaymentResponse?%s', $part, $this->getQuery());
     }

--- a/src/Concerns/Attributes.php
+++ b/src/Concerns/Attributes.php
@@ -5,6 +5,7 @@ namespace Tzsk\Payu\Concerns;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\ValidationException;
 use Tzsk\Payu\Contracts\HasFormParams;
+use Tzsk\Payu\Exceptions\InvalidValueException;
 
 class Attributes implements HasFormParams
 {
@@ -111,22 +112,26 @@ class Attributes implements HasFormParams
     }
 
     /**
-     * @throws ValidationException
+     * @throws InvalidValueException
      */
     public function validate(): array
     {
-        return Validator::make($this->toArray(), [
-            'udf1' => 'nullable|string',
-            'udf2' => 'nullable|string',
-            'udf3' => 'nullable|string',
-            'udf4' => 'nullable|string',
-            'udf5' => 'nullable|string',
-            'udf6' => 'nullable|string',
-            'udf7' => 'nullable|string',
-            'udf8' => 'nullable|string',
-            'udf9' => 'nullable|string',
-            'udf10' => 'nullable|string',
-        ])->validate();
+        try {
+            return Validator::make($this->toArray(), [
+                'udf1' => 'nullable|string',
+                'udf2' => 'nullable|string',
+                'udf3' => 'nullable|string',
+                'udf4' => 'nullable|string',
+                'udf5' => 'nullable|string',
+                'udf6' => 'nullable|string',
+                'udf7' => 'nullable|string',
+                'udf8' => 'nullable|string',
+                'udf9' => 'nullable|string',
+                'udf10' => 'nullable|string',
+            ])->validate();
+        } catch (ValidationException $e) {
+            throw new InvalidValueException($e->validator->errors()->first());
+        }
     }
 
     public function fields(): array

--- a/src/Concerns/Attributes.php
+++ b/src/Concerns/Attributes.php
@@ -130,7 +130,7 @@ class Attributes implements HasFormParams
                 'udf10' => 'nullable|string',
             ])->validate();
         } catch (ValidationException $e) {
-            throw new InvalidValueException($e->validator->errors()->first());
+            throw InvalidValueException::fromValidationException($e);
         }
     }
 

--- a/src/Concerns/Customer.php
+++ b/src/Concerns/Customer.php
@@ -5,6 +5,7 @@ namespace Tzsk\Payu\Concerns;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\ValidationException;
 use Tzsk\Payu\Contracts\HasFormParams;
+use Tzsk\Payu\Exceptions\InvalidValueException;
 
 class Customer implements HasFormParams
 {
@@ -111,22 +112,26 @@ class Customer implements HasFormParams
     }
 
     /**
-     * @throws ValidationException
+     * @throws InvalidValueException
      */
     public function validate(): array
     {
-        return Validator::make($this->toArray(), [
-            'firstname' => 'required|string',
-            'lastname' => 'nullable|string',
-            'email' => 'required|email',
-            'phone' => 'nullable|string',
-            'address1' => 'nullable|string',
-            'address2' => 'nullable|string',
-            'city' => 'nullable|string',
-            'state' => 'nullable|string',
-            'country' => 'nullable|string',
-            'zipcode' => 'nullable|string',
-        ])->validate();
+        try {
+            return Validator::make($this->toArray(), [
+                'firstname' => 'required|string',
+                'lastname' => 'nullable|string',
+                'email' => 'required|email',
+                'phone' => 'nullable|string',
+                'address1' => 'nullable|string',
+                'address2' => 'nullable|string',
+                'city' => 'nullable|string',
+                'state' => 'nullable|string',
+                'country' => 'nullable|string',
+                'zipcode' => 'nullable|string',
+            ])->validate();
+        } catch (ValidationException $e) {
+            throw new InvalidValueException($e->validator->errors()->first());
+        }
     }
 
     public function fields(): array

--- a/src/Concerns/Customer.php
+++ b/src/Concerns/Customer.php
@@ -130,7 +130,7 @@ class Customer implements HasFormParams
                 'zipcode' => 'nullable|string',
             ])->validate();
         } catch (ValidationException $e) {
-            throw new InvalidValueException($e->validator->errors()->first());
+            throw InvalidValueException::fromValidationException($e);
         }
     }
 

--- a/src/Concerns/Transaction.php
+++ b/src/Concerns/Transaction.php
@@ -86,7 +86,7 @@ class Transaction implements HasFormParams
                 'productinfo' => 'required|string',
             ])->validate();
         } catch (ValidationException $e) {
-            throw new InvalidValueException($e->validator->errors()->first());
+            throw InvalidValueException::fromValidationException($e);
         }
     }
 

--- a/src/Concerns/Transaction.php
+++ b/src/Concerns/Transaction.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Str;
 use Illuminate\Validation\ValidationException;
 use Tzsk\Payu\Contracts\HasFormParams;
+use Tzsk\Payu\Exceptions\InvalidValueException;
 
 class Transaction implements HasFormParams
 {
@@ -74,15 +75,19 @@ class Transaction implements HasFormParams
     }
 
     /**
-     * @throws ValidationException
+     * @throws InvalidValueException
      */
     public function validate(): array
     {
-        return Validator::make($this->toArray(), [
-            'txnid' => 'required|string',
-            'amount' => 'required|numeric',
-            'productinfo' => 'required|string',
-        ])->validate();
+        try {
+            return Validator::make($this->toArray(), [
+                'txnid' => 'required|string',
+                'amount' => 'required|numeric',
+                'productinfo' => 'required|string',
+            ])->validate();
+        } catch (ValidationException $e) {
+            throw new InvalidValueException($e->validator->errors()->first());
+        }
     }
 
     public function fields(): array

--- a/src/Exceptions/InvalidValueException.php
+++ b/src/Exceptions/InvalidValueException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Tzsk\Payu\Exceptions;
+
+use Exception;
+
+class InvalidValueException extends Exception
+{
+}

--- a/src/Exceptions/InvalidValueException.php
+++ b/src/Exceptions/InvalidValueException.php
@@ -3,7 +3,22 @@
 namespace Tzsk\Payu\Exceptions;
 
 use Exception;
+use Illuminate\Validation\ValidationException;
 
 class InvalidValueException extends Exception
 {
+    public ?ValidationException $validationException;
+
+    public function __construct(string $message = 'Invalid Value', ?ValidationException $ex = null) {
+        parent::__construct($message, 400, $ex);
+        $this->validationException = $ex;
+    }
+
+    public static function fromValidationException(ValidationException $ex) {
+        return new self($ex->validator->errors()->first(), $ex);
+    }
+
+    public static function fromMessage(string $message, string $field) {
+        return new self($message, ValidationException::withMessages([$field => $message]));
+    }
 }

--- a/src/Exceptions/InvalidValueException.php
+++ b/src/Exceptions/InvalidValueException.php
@@ -9,16 +9,19 @@ class InvalidValueException extends Exception
 {
     public ?ValidationException $validationException;
 
-    public function __construct(string $message = 'Invalid Value', ?ValidationException $ex = null) {
+    public function __construct(string $message = 'Invalid Value', ?ValidationException $ex = null)
+    {
         parent::__construct($message, 400, $ex);
         $this->validationException = $ex;
     }
 
-    public static function fromValidationException(ValidationException $ex) {
+    public static function fromValidationException(ValidationException $ex)
+    {
         return new self($ex->validator->errors()->first(), $ex);
     }
 
-    public static function fromMessage(string $message, string $field) {
+    public static function fromMessage(string $message, string $field)
+    {
         return new self($message, ValidationException::withMessages([$field => $message]));
     }
 }

--- a/src/Gateway/Factory.php
+++ b/src/Gateway/Factory.php
@@ -21,8 +21,8 @@ class Factory
         $factory = new self();
         $gateway = data_get($factory->gateways(), $key);
 
-        throw_unless($gateway, new InvalidValueException(__(sprintf('Gateway [%s] does not exist', $key))));
-        throw_unless($gateway instanceof Gateway, new InvalidValueException(__(sprintf('Invalid gateway [%s]', $key))));
+        throw_unless($gateway, InvalidValueException::fromMessage(__(sprintf('Gateway [%s] does not exist', $key)), $key));
+        throw_unless($gateway instanceof Gateway, InvalidValueException::fromMessage(__(sprintf('Invalid gateway [%s]', $key)), $key));
 
         return $gateway;
     }

--- a/src/Gateway/Factory.php
+++ b/src/Gateway/Factory.php
@@ -2,8 +2,7 @@
 
 namespace Tzsk\Payu\Gateway;
 
-use Illuminate\Validation\ValidationException;
-use Throwable;
+use Tzsk\Payu\Exceptions\InvalidValueException;
 
 class Factory
 {
@@ -15,15 +14,15 @@ class Factory
     /**
      * @param string $key
      * @return Gateway
-     * @throws Throwable
+     * @throws InvalidValueException
      */
     public static function make(string $key): Gateway
     {
         $factory = new self();
         $gateway = data_get($factory->gateways(), $key);
 
-        throw_unless($gateway, ValidationException::withMessages([$key => __('Gateway does not exist')]));
-        throw_unless($gateway instanceof Gateway, ValidationException::withMessages([$key => 'Invalid gateway']));
+        throw_unless($gateway, new InvalidValueException(__(sprintf('Gateway [%s] does not exist', $key))));
+        throw_unless($gateway instanceof Gateway, new InvalidValueException(__(sprintf('Invalid gateway [%s]', $key))));
 
         return $gateway;
     }

--- a/src/Gateway/PayuBiz.php
+++ b/src/Gateway/PayuBiz.php
@@ -35,7 +35,7 @@ class PayuBiz extends Gateway
     public function endpoint(): ?string
     {
         $url = data_get($this->processUrls, $this->mode);
-        throw_unless($url, new InvalidValueException(__('Invalid mode supplied for PayuBiz')));
+        throw_unless($url, InvalidValueException::fromMessage(__('Invalid mode supplied for PayuBiz'), 'mode'));
 
         return sprintf($url, $this->base);
     }
@@ -71,7 +71,7 @@ class PayuBiz extends Gateway
                 'endpoint' => 'required|url',
             ])->validate();
         } catch (ValidationException $e) {
-            throw new InvalidValueException($e->validator->errors()->first());
+            throw InvalidValueException::fromValidationException($e);
         }
     }
 

--- a/src/Gateway/PayuMoney.php
+++ b/src/Gateway/PayuMoney.php
@@ -38,7 +38,7 @@ class PayuMoney extends Gateway
     public function endpoint(): ?string
     {
         $url = data_get($this->processUrls, $this->mode);
-        throw_unless($url, new InvalidValueException(__('Invalid mode supplied for PayuMoney')));
+        throw_unless($url, InvalidValueException::fromMessage(__('Invalid mode supplied for PayuMoney'), 'mode'));
 
         return sprintf($url, $this->base);
     }
@@ -78,7 +78,7 @@ class PayuMoney extends Gateway
                 'service_provider' => 'required|string',
             ])->validate();
         } catch (ValidationException $e) {
-            throw new InvalidValueException($e->validator->errors()->first());
+            throw InvalidValueException::fromValidationException($e);
         }
     }
 

--- a/src/Payu.php
+++ b/src/Payu.php
@@ -51,7 +51,7 @@ class Payu implements HasFormParams
         try {
             Validator::make(compact('url'), ['url' => 'required|url'])->validate();
         } catch (ValidationException $e) {
-            throw new InvalidValueException($e->validator->errors()->first());
+            throw InvalidValueException::fromValidationException($e);
         }
 
         $this->destination = $url;
@@ -149,7 +149,7 @@ class Payu implements HasFormParams
                 'furl' => 'required|url',
             ])->validate();
         } catch (ValidationException $e) {
-            throw new InvalidValueException($e->validator->errors()->first());
+            throw InvalidValueException::fromValidationException($e);
         }
     }
 


### PR DESCRIPTION
### Background
This package throws Laravel's `ValidationException` when it sees any invalid data in configuration or in the Payment Payload of any sort.

A lot of Issues are being reported where devs are redirected back to the previous page because they are not catching validation exceptions. It is expected cause, that is the default behavior of Laravel for `ValidationException`.

This PR aims to throw an internal `InvalidValueException` which will be uncaught. So they will see the exception. They can easily catch this and generate the validation exception there after if they like.